### PR TITLE
Include default values in serialization.

### DIFF
--- a/Orleans.StorageProviders.SimpleSQLServerStorage/SimpleSQLServerStorage.cs
+++ b/Orleans.StorageProviders.SimpleSQLServerStorage/SimpleSQLServerStorage.cs
@@ -50,6 +50,8 @@ namespace Orleans.StorageProviders.SimpleSQLServerStorage
                 Name = name;
                 this.jsonSettings = SerializationManager.UpdateSerializerSettings(SerializationManager.GetDefaultJsonSerializerSettings(), config);
 
+                this.jsonSettings.DefaultValueHandling = DefaultValueHandling.Include;
+
                 if (!config.Properties.ContainsKey(CONNECTION_STRING) || string.IsNullOrWhiteSpace(config.Properties[CONNECTION_STRING]))
                 {
                     throw new BadProviderConfigException($"Specify a value for: {CONNECTION_STRING}");


### PR DESCRIPTION
Changed jsonSettins.DefaultValueHandling to DefaultValueHandling.Include

This will ensure that fields with default values are still included in serialization